### PR TITLE
Test script design improvement

### DIFF
--- a/src/legacy/ui/public/field_editor/components/scripting_help/_test_script.scss
+++ b/src/legacy/ui/public/field_editor/components/scripting_help/_test_script.scss
@@ -1,5 +1,5 @@
-.testScriptSearchBar {
-  .globalQueryBar {
-    padding: 8px 0px 0px 0px;
+.testScript__searchBar {
+  .globalQueryBar { 
+    padding: $euiSize 0 0;
   }
 }

--- a/src/legacy/ui/public/field_editor/components/scripting_help/test_script.js
+++ b/src/legacy/ui/public/field_editor/components/scripting_help/test_script.js
@@ -185,6 +185,7 @@ export class TestScript extends Component {
       <Fragment>
         <EuiFormRow
           label="Additional fields"
+          fullWidth
         >
           <EuiComboBox
             placeholder="Select..."
@@ -192,10 +193,11 @@ export class TestScript extends Component {
             selectedOptions={this.state.additionalFields}
             onChange={this.onAdditionalFieldsChange}
             data-test-subj="additionalFieldsSelect"
+            fullWidth
           />
         </EuiFormRow>
 
-        <div className="testScriptSearchBar">
+        <div className="testScript__searchBar">
           <SearchBar
             showFilterBar={false}
             showDatePicker={false}


### PR DESCRIPTION
Hi @friol,

I've just made a few design changes to address the PR #44220:

* We normally have a space of 16px in between form rows
* We use our Elastic UI variables to address paddings and margins instead of pixels
* Changed the class name to adhere to the BEM principle


![test script](https://user-images.githubusercontent.com/2750668/70649461-1b9fcc80-1c45-11ea-9dcb-f6024d2b6e73.png)

